### PR TITLE
feat: support namespace in helm templates

### DIFF
--- a/charts/frp-operator/templates/_helpers.tpl
+++ b/charts/frp-operator/templates/_helpers.tpl
@@ -1,3 +1,7 @@
 {{- define "frp-operator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "frp-operator.namespace" -}}
+{{- .Values.namespace | default .Release.Namespace -}}
+{{- end -}}

--- a/charts/frp-operator/templates/clusterrolebinding.yaml
+++ b/charts/frp-operator/templates/clusterrolebinding.yaml
@@ -15,4 +15,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-controller-manager
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "frp-operator.namespace" . }}

--- a/charts/frp-operator/templates/configmap.yaml
+++ b/charts/frp-operator/templates/configmap.yaml
@@ -15,6 +15,7 @@ data:
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-manager-config
+  namespace: {{ include "frp-operator.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ template "frp-operator.chart" . }}

--- a/charts/frp-operator/templates/deployment.yaml
+++ b/charts/frp-operator/templates/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ .Release.Name }}-controller-manager
+  namespace: {{ include "frp-operator.namespace" . }}
 spec:
   replicas: {{ .Values.operator.replica }}
   selector:

--- a/charts/frp-operator/templates/role.yaml
+++ b/charts/frp-operator/templates/role.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Name }}-leader-election-role
+  namespace: {{ include "frp-operator.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ template "frp-operator.chart" . }}

--- a/charts/frp-operator/templates/rolebinding.yaml
+++ b/charts/frp-operator/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-leader-election-rolebinding
+  namespace: {{ include "frp-operator.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ template "frp-operator.chart" . }}
@@ -15,4 +16,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-controller-manager
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "frp-operator.namespace" . }}

--- a/charts/frp-operator/templates/service.yaml
+++ b/charts/frp-operator/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   name: {{ .Release.Name }}-controller-manager-metrics-service
+  namespace: {{ include "frp-operator.namespace" . }}
 spec:
   ports:
   - name: https

--- a/charts/frp-operator/templates/service_account.yaml
+++ b/charts/frp-operator/templates/service_account.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-controller-manager
+  namespace: {{ include "frp-operator.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ template "frp-operator.chart" . }}

--- a/charts/frp-operator/values.yaml
+++ b/charts/frp-operator/values.yaml
@@ -1,3 +1,6 @@
+# namespace to deploy into; defaults to the Helm release namespace
+namespace: ""
+
 operator:
   # image of frp-operator
   image: "ghcr.io/zufardhiyaulhaq/frp-operator"


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first!**

_(Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request)._

### Summary

Adds `frp-operator.namespace` helper (defaults to `.Release.Namespace`, overrideable via `values.namespace`) and sets `namespace` on all namespaced resource metadata templates. Helm does this automatically when installing via `helm install`, but when templating via `helm template` (eg, if using argocd), then the manifest files do not include the namespace.

### Type of Change
This PR fixes/implements the following **bugs/features**:

- #14 

<!-- What existing problem does the pull request solve? -->

### How has this been tested?
Proof:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output or/ screenshots. -->
```shell
$ kustomize build --helm-command /opt/homebrew/opt/helm@3/bin/helm  --enable-helm frp-operator
...
kind: ConfigMap
metadata:
  labels:
    app.kubernetes.io/instance: frp-operator
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: frp-operator
    helm.sh/chart: frp-operator-1.5.0
  name: frp-operator-manager-config
  namespace: frp-operator
```

---

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have written new tests for my changes.
  - [ ] My changes successfully ran and pass tests locally.
